### PR TITLE
Initial Project (OSK-1)

### DIFF
--- a/.github/workflows/cd-workflow.yml
+++ b/.github/workflows/cd-workflow.yml
@@ -1,0 +1,33 @@
+name: .NET Test Automation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dotnet-version: [ '8.0.x' ]
+    
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
+      uses: actions/setup-dotnet@v1.7.2
+      with:
+        dotnet-version: ${{ matrix.dotnet-version }}
+    - name: Restore dependencies
+      run: >-
+        dotnet restore ./src/${{ github.event.repository.name }}.sln
+    - name: Build
+      run: dotnet build --no-restore ./src/${{ github.event.repository.name }}.sln
+    - name: Test
+      run: dotnet test --no-build --verbosity normal ./src/${{ github.event.repository.name }}.sln

--- a/.github/workflows/issueLinker-workflow.yml
+++ b/.github/workflows/issueLinker-workflow.yml
@@ -1,0 +1,23 @@
+name: Attach Issue Link
+
+on:
+  pull_request:
+    branches: [ main ]
+    
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: the-wright-jamie/update-pr-info-action@v1
+      with:
+        repo-token: "${{ secrets.GITHUB_TOKEN }}"
+        head-branch-regex: '\d+'
+        body-template: |
+          Fixes #%headbranch%
+        body-update-action: 'suffix'
+        body-uppercase-head-match: false
+        lowercase-branch: false

--- a/.github/workflows/publish-packages-workflow.yml
+++ b/.github/workflows/publish-packages-workflow.yml
@@ -1,0 +1,29 @@
+name: Publish packages
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+permissions:
+  packages: write
+  contents: read
+    
+jobs:
+  publish-nuget:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get the version
+        id: get_version
+        run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT" 
+      - uses: actions/setup-dotnet@v4.0.0
+        with:
+          dotnet-version: '8.0.x' # SDK Version to use.
+        env:
+          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_TOKEN }}
+      - run: dotnet build --configuration Release ./src /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Create the package
+        run: dotnet pack --configuration Release ./src -o . /p:Version=${{ steps.get_version.outputs.PACKAGE_VERSION }}
+      - name: Publish the package to Nuget
+        run: dotnet nuget push ./*.nupkg --api-key ${{ secrets.NUGET_TOKEN }} --source https://api.nuget.org/v3/index.json

--- a/src/OSK.Hexagonal.MetaData.UnitTests/AssemblyExtensionsTests.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/AssemblyExtensionsTests.cs
@@ -1,0 +1,72 @@
+﻿using OSK.Hexagonal.MetaData.UnitTests.Helpers;
+using System.Reflection;
+using Xunit;
+
+namespace OSK.Hexagonal.MetaData.UnitTests
+{
+    public class AssemblyExtensionsTests
+    {
+        #region Variables
+
+        private readonly Assembly _assembly;
+
+        #endregion
+
+        #region Constructors
+
+        public AssemblyExtensionsTests()
+        {
+            _assembly = Assembly.GetExecutingAssembly();
+        }
+
+        #endregion
+
+        #region GetHexagonalPortTypes
+
+        [Fact]
+        public void GetHexagonalPortTypes_None_ReturnsUnmarkedTypes()
+        {
+            // Arrange/Act
+            var types = _assembly.GetHexagonalPortTypes(HexagonalPortTypeFilter.None).ToList();
+
+            // Assert
+            Assert.Empty(types);
+        }
+
+        [Fact]
+        public void GetHexagonalPortTypes_Primary_ReturnsOnlyPrimaryPorts()
+        {
+            // Arrange/Act
+            var types = _assembly.GetHexagonalPortTypes(HexagonalPortTypeFilter.Primary).ToList();
+
+            // Assert
+            Assert.Single(types);
+            Assert.True(types.Exists(t => t == typeof(IHexagonalTestService)));
+        }
+
+        [Fact]
+        public void GetHexagonalPortTypes_Secondary_ReturnsOnlySecondaryPorts()
+        {
+            // Arrange/Act
+            var types = _assembly.GetHexagonalPortTypes(HexagonalPortTypeFilter.Secondary).ToList();
+
+            // Assert
+            Assert.Single(types);
+            Assert.True(types.Exists(t => t == typeof(IHexagonalTestRepository)));
+        }
+
+        [Fact]
+        public void GetHexagonalPortTypes_All_ReturnsAllPorts()
+        {
+            // Arrange/Act
+            var types = _assembly.GetHexagonalPortTypes(HexagonalPortTypeFilter.All).ToList();
+
+            // Assert
+            Assert.Equal(2, types.Count);
+            Assert.True(types.Exists(t => t == typeof(IHexagonalTestService)));
+            Assert.True(types.Exists(t => t == typeof(IHexagonalTestRepository)));
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/IHexagonalTestRepository.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/IHexagonalTestRepository.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    [HexagonalPort(HexagonalPort.Secondary)]
+    public interface IHexagonalTestRepository
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/IHexagonalTestService.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/IHexagonalTestService.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    public interface IHexagonalTestService
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/INonExportedHexagonalService.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/INonExportedHexagonalService.cs
@@ -1,0 +1,7 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    [HexagonalPort(HexagonalPort.Primary)]
+    internal interface INonExportedHexagonalService
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/INonExportedRepository.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/INonExportedRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    internal interface INonExportedRepository
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/ITestRepository.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/ITestRepository.cs
@@ -1,0 +1,6 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    public interface ITestRepository
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/ITestService.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Helpers/ITestService.cs
@@ -1,0 +1,6 @@
+﻿namespace OSK.Hexagonal.MetaData.UnitTests.Helpers
+{
+    public interface ITestService
+    {
+    }
+}

--- a/src/OSK.Hexagonal.MetaData.UnitTests/OSK.Hexagonal.MetaData.UnitTests.csproj
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/OSK.Hexagonal.MetaData.UnitTests.csproj
@@ -1,0 +1,22 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>net8.0</TargetFramework>
+		<ImplicitUsings>enable</ImplicitUsings>
+		<Nullable>enable</Nullable>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+		<PackageReference Include="xunit" Version="2.9.2" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\OSK.Hexagonal.MetaData\OSK.Hexagonal.MetaData.csproj" />
+	</ItemGroup>
+
+</Project>

--- a/src/OSK.Hexagonal.MetaData.sln
+++ b/src/OSK.Hexagonal.MetaData.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.35312.102
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.Hexagonal.MetaData", "OSK.Hexagonal.MetaData\OSK.Hexagonal.MetaData.csproj", "{0E8F10BA-CF94-478E-81F2-AEFF1DEDDB7A}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSK.Hexagonal.MetaData.UnitTests", "OSK.Hexagonal.MetaData.UnitTests\OSK.Hexagonal.MetaData.UnitTests.csproj", "{EC328300-6EE0-4F00-BDA9-FB327CE0F8A6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0E8F10BA-CF94-478E-81F2-AEFF1DEDDB7A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E8F10BA-CF94-478E-81F2-AEFF1DEDDB7A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E8F10BA-CF94-478E-81F2-AEFF1DEDDB7A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E8F10BA-CF94-478E-81F2-AEFF1DEDDB7A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC328300-6EE0-4F00-BDA9-FB327CE0F8A6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC328300-6EE0-4F00-BDA9-FB327CE0F8A6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC328300-6EE0-4F00-BDA9-FB327CE0F8A6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC328300-6EE0-4F00-BDA9-FB327CE0F8A6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {19F3E7EE-834E-459B-A21A-DB679EAE963F}
+	EndGlobalSection
+EndGlobal

--- a/src/OSK.Hexagonal.MetaData/AssemblyExtensions.cs
+++ b/src/OSK.Hexagonal.MetaData/AssemblyExtensions.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace OSK.Hexagonal.MetaData
+{
+    public static class AssemblyExtensions
+    {
+        public static IEnumerable<Type> GetHexagonalPortTypes(this Assembly assembly)
+            => assembly.GetHexagonalPortTypes(HexagonalPortTypeFilter.All);
+
+        public static IEnumerable<Type> GetHexagonalPortTypes(this Assembly assembly, HexagonalPortTypeFilter filter)
+            => filter == HexagonalPortTypeFilter.None 
+             ? Type.EmptyTypes 
+             : assembly.GetExportedTypes().Where(type =>
+             {
+                 if (!type.IsInterface)
+                 {
+                     return false;
+                 }
+
+                 var hexagonalPort = type.GetCustomAttribute<HexagonalPortAttribute>();
+                 if (hexagonalPort == null)
+                 {
+                    return false;
+                 }
+                 if (filter == HexagonalPortTypeFilter.All)
+                 {
+                    return true;
+                 }
+
+                 return filter.HasFlag(HexagonalPortTypeFilter.Primary)
+                    ? hexagonalPort.HexagonalPort == HexagonalPort.Primary
+                    : hexagonalPort.HexagonalPort == HexagonalPort.Secondary;
+             });
+    }
+}

--- a/src/OSK.Hexagonal.MetaData/HexagonalPort.cs
+++ b/src/OSK.Hexagonal.MetaData/HexagonalPort.cs
@@ -1,0 +1,18 @@
+﻿namespace OSK.Hexagonal.MetaData
+{
+    /// <summary>
+    /// An enum list that defines the types of ports that can be utilized in the hexagonal library design
+    /// </summary>
+    public enum HexagonalPort
+    {
+        /// <summary>
+        /// An interface whose primary implementation will be provided by the library.
+        /// </summary>
+        Primary,
+
+        /// <summary>
+        /// An interface whose implementation must be provided by the consumer of the library
+        /// </summary>
+        Secondary
+    }
+}

--- a/src/OSK.Hexagonal.MetaData/HexagonalPortAttribute.cs
+++ b/src/OSK.Hexagonal.MetaData/HexagonalPortAttribute.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace OSK.Hexagonal.MetaData
+{
+    /// <summary>
+    /// An attribute that can be used to desginate an interface as a type of hexagonal port
+    /// </summary>
+    [AttributeUsage(validOn: AttributeTargets.Interface, AllowMultiple = false)]
+    public class HexagonalPortAttribute: Attribute
+    {
+        #region Variables
+
+        public HexagonalPort HexagonalPort { get; }
+
+        #endregion
+
+        #region Constructors
+
+        public HexagonalPortAttribute(HexagonalPort hexagonalPort)
+        {
+            HexagonalPort = hexagonalPort;
+        }
+
+        #endregion
+    }
+}

--- a/src/OSK.Hexagonal.MetaData/HexagonalPortTypeFilter.cs
+++ b/src/OSK.Hexagonal.MetaData/HexagonalPortTypeFilter.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace OSK.Hexagonal.MetaData
+{
+    [Flags]
+    public enum HexagonalPortTypeFilter
+    {
+        None = 0,
+        Primary = 1,
+        Secondary = 2,
+
+        All = Primary | Secondary
+    }
+}

--- a/src/OSK.Hexagonal.MetaData/OSK.Hexagonal.MetaData.csproj
+++ b/src/OSK.Hexagonal.MetaData/OSK.Hexagonal.MetaData.csproj
@@ -1,0 +1,13 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+	<PropertyGroup>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Hexagonal.MetaData</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<Description>A metadata library that can be used in conjunction with a hexagonally developed library to better designate the interfaces that are implemented by the library vs. the consumer.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, MetaData, Meta, Data, Hexagonal, Architecture, Marker, Interface, Implementation, Port, Adapter</PackageTags>
+		<Authors>BlankDev117</Authors>
+		<Title>OSK.Hexagonal.MetaData</Title>
+	</PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Motivation
----
Want an initial project that is capable of designating the ports/adapter pattern for hexagonally developed .NET libraries

Modifications
----
* Added initial project
* Added UnitTests
* Added workflows

Result
----
An initial project capable of designating the interfaces for the port/adapter pattern is now available

Fixes #1