### PR TITLE
Throw HexagonalMetaData Exception and minor changes (OSK-5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # OSK.Hexagonal.MetaData
-This project is meant to provide a way to mark, directly in code, the expecation of a given abstraction for a hexagonally implemented
+This project is meant to provide a way to mark, directly in code, the expectation of a given abstraction for a hexagonally implemented
 library. By using this kind of metadata, a codebase may hopefully be more clearly documented to its intentions and usage. There is also
 a set of assembly extensions that can be used to retrieve specific types of abstractions based on their hexagonal integration type metadata.
 
 # Usage
 Codebase abstractions, i.e. interfaces, can be marked using the `HexagonalIntegrationAttribute` and can be marked in a variety of ways 
 to help provide code readers an idea to the intentions of the port at a glance. The attribute can be defined with one or more hexagonal integration
-types. 
+types. These types help to define expectations for integrations, consumers, and direct implementations of the library.
 
 Note: There is some additional logic in place to restrict some combinations of integration types. For example, an abstraction can 
 not be both marked as required and optional. This is to help reduce potential confusion for a codebase when using this library. The attribute

--- a/src/OSK.Hexagonal.MetaData.UnitTests/Internal/Helpers/HexagonalHelperTests.cs
+++ b/src/OSK.Hexagonal.MetaData.UnitTests/Internal/Helpers/HexagonalHelperTests.cs
@@ -1,4 +1,5 @@
-﻿using OSK.Hexagonal.MetaData.Internal.Helpers;
+﻿using OSK.Hexagonal.MetaData.Exceptions;
+using OSK.Hexagonal.MetaData.Internal.Helpers;
 using Xunit;
 
 namespace OSK.Hexagonal.MetaData.UnitTests.Internal.Helpers
@@ -20,7 +21,7 @@ namespace OSK.Hexagonal.MetaData.UnitTests.Internal.Helpers
             params HexagonalIntegrationType[] mismatchedTypes)
         {
             // Arrange/Act/Assert
-            Assert.Throws<InvalidOperationException>(() => HexagonalHelper.ValidateHexagonalIntegration(mismatchedTypes.ToHashSet()));
+            Assert.Throws<HexagonalMetaDataException>(() => HexagonalHelper.ValidateHexagonalIntegration(mismatchedTypes.ToHashSet()));
         }
 
 

--- a/src/OSK.Hexagonal.MetaData/Internal/Helpers/HexagonalHelper.cs
+++ b/src/OSK.Hexagonal.MetaData/Internal/Helpers/HexagonalHelper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OSK.Hexagonal.MetaData.Exceptions;
 
 namespace OSK.Hexagonal.MetaData.Internal.Helpers
 {
@@ -13,15 +14,15 @@ namespace OSK.Hexagonal.MetaData.Internal.Helpers
 
             if (isRequired && isOptional)
             {
-                throw new InvalidOperationException("Unable to set an integration type as both required and optional.");
+                throw new HexagonalMetaDataException("Unable to set an integration type as both required and optional.");
             }
             if (isRequired && hexagonalIntegrationTypes.Contains(HexagonalIntegrationType.LibraryProvided))
             {
-                throw new InvalidOperationException("Unable to set an integration type as required if it is already provided by the library.");
+                throw new HexagonalMetaDataException("Unable to set an integration type as required if it is already provided by the library.");
             }
             if (isOptional && hexagonalIntegrationTypes.Contains(HexagonalIntegrationType.ConsumerPointOfEntry))
             {
-                throw new InvalidOperationException("Unable to set an integration type as a consumer point of entry while it is optional");
+                throw new HexagonalMetaDataException("Unable to set an integration type as a consumer point of entry while it is optional");
             }
         }
     }

--- a/src/OSK.Hexagonal.MetaData/OSK.Hexagonal.MetaData.csproj
+++ b/src/OSK.Hexagonal.MetaData/OSK.Hexagonal.MetaData.csproj
@@ -5,8 +5,8 @@
 		<TargetFramework>netstandard2.1</TargetFramework>
 		<RepositoryUrl>https://github.com/OpenSourceKingdom/OSK.Hexagonal.MetaData</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
-		<Description>A metadata library that can be used in conjunction with a hexagonally developed library to better designate the interfaces that are implemented by the library vs. the consumer.</Description>
-		<PackageTags>OpenSourceKingdom, OpenSource, MetaData, Meta, Data, Hexagonal, Architecture, Marker, Interface, Implementation, Port, Adapter</PackageTags>
+		<Description>A metadata library that can be used in conjunction with a hexagonally developed library to better designate the interfaces that are implemented by the library vs. the consumer or integrations. Aim is to enhance code readability and expected usage at a glance.</Description>
+		<PackageTags>OpenSourceKingdom, OpenSource, MetaData, Meta, Data, Hexagonal, Architecture, Marker, Interface, Implementation, Port, Adapter, Integration, Consumer, Type</PackageTags>
 		<Authors>BlankDev117</Authors>
 		<Title>OSK.Hexagonal.MetaData</Title>
 


### PR DESCRIPTION
Motivation
----
Previously an invalid operation exception was being thrown when the HexagonalMetaDataException was expected

Modifications
----
* Throw expected exception
* Updated UnitTests
* Updated README and nuget docs for potential visibility

Result
----
Expected exception is thrown and some slightly updated docs

Fixes #5